### PR TITLE
Set gravity and start overworld directly

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,6 @@
-
 import * as ex from "excalibur";
 import { Player } from './player';
 import { Resources, loader } from "./resources";
-import { House } from "./house";
 import { Overworld } from "./overworld";
 
 const game = new ex.Engine({
@@ -14,16 +12,10 @@ const game = new ex.Engine({
     displayMode: ex.DisplayMode.FitScreenAndFill,
     pixelArt: true,
     pixelRatio: 4,
+    physics: { gravity: ex.vec(0, 1200) },
     scenes: {
         overworld: {
             scene: Overworld,
-            transitions: {
-                out: new ex.FadeInOut({direction: 'out', duration: 1000, color: ex.Color.Black}),
-                in: new ex.FadeInOut({direction: 'in', duration: 1000, color: ex.Color.Black})
-            }
-        },
-        house: {
-            scene: House,
             transitions: {
                 out: new ex.FadeInOut({direction: 'out', duration: 1000, color: ex.Color.Black}),
                 in: new ex.FadeInOut({direction: 'in', duration: 1000, color: ex.Color.Black})
@@ -44,27 +36,6 @@ Resources.LdtkResource.registerEntityIdentifierFactory('PlayerStart', (props) =>
     return player;
 });
 
-Resources.LdtkResource.registerEntityIdentifierFactory('Door', (props) => {
-    const trigger = new ex.Trigger({
-        width: props.entity.width,
-        height: props.entity.height,
-        pos: props.worldPos.add(ex.vec(props.entity.width/2, props.entity.height/2)),
-        filter: (entity) => {
-            return entity instanceof Player
-        },
-        action: () => {
-            game.goToScene(props.entity.fieldInstances[0].__value);
-        }
-    });
-    return trigger;
-});
-
-const inTransition = new ex.FadeInOut({
-    duration: 1000,
-    direction: 'in',
-    color: ex.Color.ExcaliburBlue
-});
 game.start('overworld', {
-    loader,
-    inTransition
+    loader
 });


### PR DESCRIPTION
## Summary
- Configure engine gravity for platforming
- Remove house scene and door triggers
- Start game in overworld with PlayerStart factory

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a8279ed208325885db2aca5cf6cf0