### PR TITLE
refactor: simplify player to rectangle with platformer controls

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -1,128 +1,33 @@
 import * as ex from 'excalibur';
-import { Resources } from './resources';
-import { Config } from './config';
 
 export class Player extends ex.Actor {
+    private moveSpeed = 200;
+    private jumpSpeed = 400;
+
     constructor(args: ex.ActorArgs) {
         super({
             ...args,
+            anchor: ex.vec(0.5, 1),
             collisionType: ex.CollisionType.Active
-        })
+        });
+
+        this.graphics.use(new ex.Rectangle({ width: 20, height: 32, color: ex.Color.Red }));
+        (this.body as any).useBoxCollider(20, 32);
     }
 
-    onInitialize(engine: ex.Engine): void {
-        const playerSpriteSheet = ex.SpriteSheet.fromImageSource({
-            image: Resources.HeroSpriteSheetPng as ex.ImageSource,
-            grid: {
-                spriteWidth: 16,
-                spriteHeight: 16,
-                rows: 8,
-                columns: 8
-            }
-        });
+    onPreUpdate(engine: ex.Engine): void {
+        this.vel.x = 0;
 
-        const leftIdle = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 1) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 1) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 1) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 1) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        })
-        this.graphics.add('left-idle', leftIdle);
-
-        const rightIdle = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 2) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 2) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 2) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 2) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        })
-        this.graphics.add('right-idle', rightIdle);
-
-
-        const upIdle = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 3) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 3) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 3) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 3) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        })
-        this.graphics.add('up-idle', upIdle);
-
-        const downIdle = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 0) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 0) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 0) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 0) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        })
-        this.graphics.add('down-idle', downIdle);
-
-        const leftWalk = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 5) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 5) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 5) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 5) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        })
-        this.graphics.add('left-walk', leftWalk);
-
-        const rightWalk = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 6) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 6) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 6) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 6) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        });
-        this.graphics.add('right-walk', rightWalk);
-
-        const upWalk = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 7) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 7) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 7) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 7) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        });
-        this.graphics.add('up-walk', upWalk);
-
-        const downWalk = new ex.Animation({
-            frames: [
-                {graphic: playerSpriteSheet.getSprite(0, 4) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(1, 4) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(2, 4) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-                {graphic: playerSpriteSheet.getSprite(3, 4) as ex.Sprite, duration: Config.PlayerFrameSpeed},
-            ]
-        });
-        this.graphics.add('down-walk', downWalk);
-    }
-
-    onPreUpdate(engine: ex.Engine, elapsedMs: number): void {
-        this.vel = ex.Vector.Zero;
-
-        this.graphics.use('down-idle');
-        if (engine.input.keyboard.isHeld(ex.Keys.ArrowRight)) {
-            this.vel = ex.vec(Config.PlayerSpeed, 0);
-            this.graphics.use('right-walk');
-        }
-        if (engine.input.keyboard.isHeld(ex.Keys.ArrowLeft)) {
-            this.vel = ex.vec(-Config.PlayerSpeed, 0);
-            this.graphics.use('left-walk');
-        }
-        if (engine.input.keyboard.isHeld(ex.Keys.ArrowUp)) {
-            this.vel = ex.vec(0, -Config.PlayerSpeed);
-            this.graphics.use('up-walk');
-        }
-        if (engine.input.keyboard.isHeld(ex.Keys.ArrowDown)) {
-            this.vel = ex.vec(0, Config.PlayerSpeed);
-            this.graphics.use('down-walk');
+        if (engine.input.keyboard.isHeld(ex.Keys.ArrowLeft) || engine.input.keyboard.isHeld(ex.Keys.A)) {
+            this.vel.x = -this.moveSpeed;
         }
 
+        if (engine.input.keyboard.isHeld(ex.Keys.ArrowRight) || engine.input.keyboard.isHeld(ex.Keys.D)) {
+            this.vel.x = this.moveSpeed;
+        }
+
+        if ((engine.input.keyboard.wasPressed(ex.Keys.Space) || engine.input.keyboard.wasPressed(ex.Keys.Z)) && (this.body as any).contact?.solids.bottom) {
+            this.vel.y = -this.jumpSpeed;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace sprite-based player with simple rectangle and box collider
- add horizontal movement and jumping with keyboard controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689af45372988325b3bc9ee8db6f6e3a