### PR TITLE
Add camera dead-zone for player tracking

### DIFF
--- a/src/overworld.ts
+++ b/src/overworld.ts
@@ -1,4 +1,5 @@
-import { Actor, Engine, Scene, SceneActivationContext, TransformComponent, vec } from "excalibur";
+import { Actor, Engine, Scene, SceneActivationContext, vec } from "excalibur";
+import * as ex from "excalibur";
 import { Resources } from "./resources";
 import { Player } from "./player";
 
@@ -14,8 +15,26 @@ export class Overworld extends Scene {
 
     onActivate(context: SceneActivationContext<unknown>): void {
         const player = this.world.entityManager.getByName('player')[0];
+        const engine = this.engine;
+        const dz = ex.vec(engine.drawWidth * 0.25, engine.drawHeight * 0.25);
         if (player instanceof Player) {
-            this.camera.strategy.lockToActor(player as Actor);
+            const deadZoneStrategy: ex.CameraStrategy<Actor> = {
+                target: player as Actor,
+                action: (target, cam) => {
+                    const focus = cam.getFocus();
+                    const diff = target.center.sub(focus);
+                    let newX = focus.x;
+                    let newY = focus.y;
+                    if (Math.abs(diff.x) > dz.x) {
+                        newX = target.center.x - Math.sign(diff.x) * dz.x;
+                    }
+                    if (Math.abs(diff.y) > dz.y) {
+                        newY = target.center.y - Math.sign(diff.y) * dz.y;
+                    }
+                    return ex.vec(newX, newY);
+                }
+            };
+            this.camera.addStrategy(deadZoneStrategy);
         }
         const bounds = Resources.LdtkResource.getLevelBounds(['Level_0', 'Level_1']);
         this.camera.strategy.limitCameraBounds(bounds);


### PR DESCRIPTION
## Summary
- Add dead-zone vector and custom camera strategy so camera follows player with ~25% slack
- Preserve existing camera bounds limiting

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689af950267c8325b27c8c74c805bb5c