### PR TITLE
Add IntGrid colliders and player spawn

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,4 +38,21 @@ Resources.LdtkResource.registerEntityIdentifierFactory('PlayerStart', (props) =>
 
 game.start('overworld', {
     loader
+}).then(() => {
+    const scene = game.currentScene;
+    if (scene.world.entityManager.getByName('player').length === 0) {
+        const playerStart = Resources.LdtkResource.getLdtkEntitiesByIdentifier('PlayerStart', ['Level_0', 'Level_1'])[0];
+        if (playerStart) {
+            const pos = ex.vec(playerStart.__worldX ?? playerStart.px[0], playerStart.__worldY ?? playerStart.px[1]);
+            const player = new Player({
+                name: 'player',
+                anchor: ex.vec(playerStart.__pivot[0], playerStart.__pivot[1]),
+                width: playerStart.width,
+                height: playerStart.height,
+                pos,
+                z: 0
+            });
+            scene.add(player);
+        }
+    }
 });

--- a/src/overworld.ts
+++ b/src/overworld.ts
@@ -5,12 +5,53 @@ import { Player } from "./player";
 
 
 export class Overworld extends Scene {
-    
+
     onInitialize(engine: Engine<any>): void {
         Resources.LdtkResource.addToScene(this, {
             pos: vec(0, 0),
             levelFilter: ['Level_0', 'Level_1']
         });
+
+        const solidLayers = Resources.LdtkResource.getIntGridLayers('Solids');
+        for (const layer of solidLayers) {
+            const tileSize = layer.ldtkLayer.__gridSize;
+            const width = layer.ldtkLayer.__cWid;
+            const height = layer.ldtkLayer.__cHei;
+            const worldX = layer.worldPos.x;
+            const worldY = layer.worldPos.y;
+            const data = layer.ldtkLayer.intGridCsv;
+
+            for (let y = 0; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                    const index = y * width + x;
+                    if (data[index] === 1) {
+                        const collider = new ex.Actor({
+                            pos: ex.vec(worldX + x * tileSize + tileSize / 2, worldY + y * tileSize + tileSize / 2),
+                            width: tileSize,
+                            height: tileSize,
+                            collisionType: ex.CollisionType.Fixed
+                        });
+                        this.add(collider);
+                    }
+                }
+            }
+        }
+
+        if (this.world.entityManager.getByName('player').length === 0) {
+            const playerStart = Resources.LdtkResource.getLdtkEntitiesByIdentifier('PlayerStart', ['Level_0', 'Level_1'])[0];
+            if (playerStart) {
+                const pos = ex.vec(playerStart.__worldX ?? playerStart.px[0], playerStart.__worldY ?? playerStart.px[1]);
+                const player = new Player({
+                    name: 'player',
+                    pos,
+                    width: playerStart.width,
+                    height: playerStart.height,
+                    anchor: ex.vec(playerStart.__pivot[0], playerStart.__pivot[1]),
+                    z: 0
+                });
+                this.add(player);
+            }
+        }
     }
 
     onActivate(context: SceneActivationContext<unknown>): void {


### PR DESCRIPTION
## Summary
- Build colliders from LDtk `Solids` IntGrid cells and add fallback player spawn in Overworld scene
- Verify and spawn player from `PlayerStart` data if factory missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689afc309778832596932f9c0c83c312