### PR TITLE
refactor: use new collider API for player

### DIFF
--- a/src/player.ts
+++ b/src/player.ts
@@ -12,7 +12,7 @@ export class Player extends ex.Actor {
         });
 
         this.graphics.use(new ex.Rectangle({ width: 20, height: 32, color: ex.Color.Red }));
-        (this.body as any).useBoxCollider(20, 32);
+        this.collider.useBoxCollider(20, 32);
     }
 
     onPreUpdate(engine: ex.Engine): void {


### PR DESCRIPTION
## Summary
- use `this.collider.useBoxCollider` for a 20x32 collider instead of deprecated body API
- keep player actor dynamic and maintain grounded jumping check

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b284bfa108325b964b0b957770ec7