### PR TITLE
refactor LDtk resource setup

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -5,24 +5,28 @@ import tilesetPath from '../res/Solaria Demo Pack Update 03/Solaria Demo Pack Up
 import ldtkLevel0 from '../res/top-down/Level_0.ldtkl?url';
 import ldtkLevel1 from '../res/top-down/Level_1.ldtkl?url';
 import ldtkHouse from '../res/top-down/House.ldtkl?url';
-import ldtkPath from '../res/top-down.ldtk?url';
 
 export const Resources = {
     HeroSpriteSheetPng: new ImageSource(heroImgPath),
-    LdtkResource: new LdtkResource(ldtkPath, {
+    LdtkResource: new LdtkResource('/res/top-down/top-down.ldtk', {
         useTilemapCameraStrategy: true,
         useMapBackgroundColor: true,
         // Path map intercepts and redirects to work around parcel's static bundling
-        pathMap: [
-            { path: 'Hero 01.png', output: heroImgPath },
-            { path: 'Level_0.ldtkl', output: ldtkLevel0 },
-            { path: 'Level_1.ldtkl', output: ldtkLevel1 },
-            { path: 'House.ldtkl', output: ldtkHouse },
-            { path: 'Solaria Demo Update 01.png', output: tilesetPath },
-        ]
+        pathMap: {
+            'Hero 01.png': heroImgPath,
+            'Level_0.ldtkl': ldtkLevel0,
+            'Level_1.ldtkl': ldtkLevel1,
+            'House.ldtkl': ldtkHouse,
+            'Solaria Demo Update 01.png': tilesetPath,
+        } as any
     })
 } as const;
 
+// Temporary debug load event
+(Resources.LdtkResource as any).on('load', () => {
+    console.log('ldtkLevel1:', ldtkLevel1);
+    console.log('tilesetPath:', tilesetPath);
+});
 
 export const loader = new Loader();
 for (let resource of Object.values(Resources)) {


### PR DESCRIPTION
## Summary
- simplify LDtk resource by using direct project path and object-based path map
- add temporary debug logging for level and tileset paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b2aa335a88325a53b51d53535b51a