### PR TITLE
Set engine pixelRatio to 1 for development

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ const game = new ex.Engine({
     suppressPlayButton: true,
     displayMode: ex.DisplayMode.FitScreenAndFill,
     pixelArt: true,
-    pixelRatio: 4,
+    pixelRatio: 1,
     physics: { gravity: ex.vec(0, 1200) },
     scenes: {
         overworld: {


### PR DESCRIPTION
## Summary
- configure Excalibur Engine to use `pixelRatio: 1` to prevent HiDPI warnings during development

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b2bd70a948325a0ebc955337fa216